### PR TITLE
Add publishing workflow

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -17,6 +17,9 @@ case $BUILDKITE_STEP_KEY in
   test)
     asdf_add_to_shell
     ;;
+  publish)
+    asdf_add_to_shell
+    ;;
   *)
     describe "Skipping pre-command hook"
     ;;

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,3 +19,7 @@ steps:
     key: test
     command: ./bin/ci
     plugins: *all-plugins
+  - label: "Publish to :hex:"
+    key: publish
+    command: ./bin/publish
+    branches: main

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source bin/functions.sh
+
+version="v$1"
+
+describe "Creating git tag $version"
+git tag $version
+git push origin --tags
+
+describe "Publishing the package to hex"
+mix hex.publish --yes

--- a/mix.exs
+++ b/mix.exs
@@ -5,17 +5,27 @@ defmodule BuildpacksRegistryApi.MixProject do
   defp elixirc_paths(:dev), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
+  @source_url "https://github.com/flowerworkio/buildpacks_registry_api"
+  @api_spec_url "https://github.com/buildpacks/registry-api"
+
   def project do
     [
       app: :buildpacks_registry_api,
+      deps: deps(),
       description: """
       An API client for the buildpacks registry with caching.
       """,
-      deps: deps(),
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
-      homepage_url: "https://github.com/flowerworkio/buildpacks_registry_api",
-      source_url: "https://github.com/flowerworkio/buildpacks_registry_api",
+      homepage_url: @source_url,
+      licenses: ["Apache-2.0"],
+      links: %{
+        "Source code" => @source_url,
+        "API Spec" => @api_spec_url,
+        "Buildpacks Registry" => "https://registry.buildpacks.io"
+      },
+      organization: "flowerworkio",
+      source_url: @source_url,
       start_permanent: Mix.env() == :prod,
       version: "0.1.0"
     ]


### PR DESCRIPTION
### Changelog
- Added a HEX_API_KEY for the flowerworkio organization on hex.pm to the buildkite-agent environment hook
- Added bin/publish script for publishing the git tag and hex package and hex docs
- Configured buildkite to run the publish script on merges to `main`
- Added metadata to the Mixfile to generate better information for the package